### PR TITLE
couple o` bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Javascript.
 Run the following:
 
 ```
-    mkdir pat-example && cd pat-example
     yo patternslib pat-example 
 ```
 

--- a/app/index.js
+++ b/app/index.js
@@ -7,58 +7,50 @@ var PatternGenerator = yeoman.generators.Base.extend({
     'use strict';
     yeoman.generators.Base.apply(this, arguments);
 
+    this.argument('app_name', { type: String, required: true });
+    this.appname = this.app_name || this.appname;
     this.option('appPath', {
       desc: 'Name of application directory',
       type: 'String',
-      defaults: './',
+      defaults: this.appname,
       banner: 'some banner'
     });
-    this.argument('app_name', { type: String, required: false });
-    this.appname = this.app_name || this.appname;
-    this.env.options.appPath = this.options.appPath || './';
+    this.env.options.appPath = this.options.appPath;
     this.config.set('appPath', this.env.options.appPath);
-    this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
   },
 
   writing: {
-    setupEnv: function () {
+
+    setup_base: function () {
       this.mkdir(this.env.options.appPath);
       this.mkdir(this.env.options.appPath + '/src');
+    },
+
+    setup_bower: function () {
+      this.template('bowerrc', this.env.options.appPath + '/.bowerrc');
+      this.copy('_bower.json', this.env.options.appPath + '/bower.json');
+    },
+
+    setup_node: function () {
+      this.template('_package.json', this.env.options.appPath + '/package.json');
+    },
+
+    setup_devenv: function () {
+      this.copy('editorconfig', this.env.options.appPath + '/.editorconfig');
+      this.template('gitignore', this.env.options.appPath + '/.gitignore');
+      this.copy('jshintrc', this.env.options.appPath + '/.jshintrc');
+      this.copy('Makefile', this.env.options.appPath + '/Makefile');
+    },
+
+    setup_index: function () {
+      this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), '/index.html'));
+      this.indexFile = this.engine(this.indexFile, this);
       this.write(this.env.options.appPath + '/index.html', this.indexFile);
     },
 
-    git: function () {
-      this.template('gitignore', '.gitignore');
-    },
-
-    bower: function () {
-      this.template('bowerrc', '.bowerrc');
-      this.copy('_bower.json', 'bower.json');
-    },
-
-    jshint: function () {
-      this.copy('jshintrc', '.jshintrc');
-    },
-
-    editorConfig: function () {
-      this.copy('editorconfig', '.editorconfig');
-    },
-
-    copyMakeFile: function () {
-      this.copy('Makefile', 'Makefile');
-    },
-
-    packageJSON: function () {
-      this.template('_package.json', 'package.json');
-    },
-
-    writeIndex: function () {
-      this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
-      this.indexFile = this.engine(this.indexFile, this);
-    },
-
-    createPatternFile: function () {
-      this.template("pattern.js", this.env.options.appPath + '/src/pattern.js');
+    setup_app: function () {
+      this.template("main.js",    this.env.options.appPath + '/main.js');
+      this.template("pattern.js", this.env.options.appPath + '/src/' + this.appname + '.js');
     }
   }
 });

--- a/app/templates/Makefile
+++ b/app/templates/Makefile
@@ -1,26 +1,17 @@
 BOWER 		?= node_modules/.bin/bower
 HTTPSERVE   ?= node_modules/.bin/http-server
 
-all:: designerhappy
-
-########################################################################
-## Install dependencies
-
-stamp-npm: package.json
-	npm install
-	touch stamp-npm
-
-stamp-bower: stamp-npm
-	$(BOWER) install
-	touch stamp-bower
+all:: install serve
+	printf "\n\n All done!\n\n Go to http://localhost:4001/ to see a demo.\n\n\n\n"
 
 clean::
-	rm -f stamp-npm stamp-bower
 	rm -rf node_modules src/bower_components ~/.cache/bower
 
-make serve::
+install:
+	npm install
+	$(BOWER) install
+
+serve::
 	$(HTTPSERVE) -p 4001
 
-designerhappy:: stamp-npm stamp-bower
-	printf "\n\n Designer, you can be happy now.\n Go to http://localhost:4001/ to see a demo \n\n\n\n"
-	$(HTTPSERVE) -p 4001
+.PHONY: all clean install serve

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -5,6 +5,9 @@
   "dependencies": {
     "patternslib": "master"
   },
+  "resolutions": {
+    "jquery": "1.11.1"
+  },
   "keywords": [
     "patternslib",
     "pattern"

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "bower": "latest",
     "requirejs": "",
-    "http-server": "^0.7.3"
+    "http-server": ""
   }
 }

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,6 +1,4 @@
 node_modules
 src/bower_components
-stamp-bower
-stamp-npm
 *~
 .*.sw?

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,15 +1,13 @@
 <!DOCTYPE HTML>
 <html>
-<head>
+  <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <title><%= _.slugify(appname) %> demo</title>
     <script data-main="main" src="src/bower_components/requirejs/require.js"></script>
-</head>
-<body role="document">
-    <div class="container">
+  </head>
+  <body role="document">
+    <div class="<%= _.slugify(appname) %>" data-<%= _.slugify(appname) %>="">
         <h1><%= _.slugify(appname) %> demo</h1>
-
-        
     </div>
-</body>
+  </body>
 </html>

--- a/app/templates/main.js
+++ b/app/templates/main.js
@@ -1,8 +1,8 @@
 require.config({
     baseUrl: "src",
     paths: {
-        "ckeditor":                     "bower_components/ckeditor/ckeditor",
-        "ckeditor-jquery":              "bower_components/ckeditor/adapters/jquery",
+        // Add any other dependencies here. For external libraries, also add
+        // them to bower.json
         "jquery":                       "bower_components/jquery/dist/jquery",
         "jquery.browser":               "bower_components/jquery.browser/dist/jquery.browser",
         "logging":                      "bower_components/logging/src/logging",
@@ -10,19 +10,23 @@ require.config({
         "pat-compat":                   "bower_components/patternslib/src/core/compat",
         "pat-jquery-ext":               "bower_components/patternslib/src/core/jquery-ext",
         "pat-logger":                   "bower_components/patternslib/src/core/logger",
+        "pat-mockup-parser":            "bower_components/patternslib/src/core/mockup-parser",
         "pat-parser":                   "bower_components/patternslib/src/core/parser",
         "pat-registry":                 "bower_components/patternslib/src/core/registry",
         "pat-utils":                    "bower_components/patternslib/src/core/utils",
-        "patterns":                     "bower_components/patternslib/bundle",
-        "underscore":                   "bower_components/underscore/underscore",
+        "underscore":                   "bower_components/underscore/underscore"
+
     },
     "shim": {
-        "logging": { "exports": "logging" },
-        "ckeditor-jquery":{ deps:["jquery","ckeditor"] }
+        "logging": { "exports": "logging" }
     }
 });
 
-require(["pat-registry", "pat-ckeditor"], function(registry, editor) {
+require(["pat-registry", "<%= appname %>"], function(registry, pattern) {
+    // your pattern is found via it's name in the filesystem, starting from the
+    // requireJS baseUrl option: "<%= appname %>"
     window.patterns = registry;
-    registry.init();
+    $(document).ready(function() {
+        registry.init();
+    });
 });

--- a/app/templates/pattern.js
+++ b/app/templates/pattern.js
@@ -19,12 +19,13 @@
 }(this, function($, Base, registry, Parser, logger) {
     'use strict';
 
-    var log = logger.getLogger("pat-clone");
+    var log = logger.getLogger("<%= appname %>");
     /* For logging, you can call log.debug, log.info, log.warn, log.error and log.fatal.
      *
      * For more information on how to use the logger and how to view log messages, please read:
      * https://github.com/Patternslib/logging
      */
+    log.debug("pattern loaded");
 
     var parser = new Parser('<%= appname.split("-")[1] %>');
     /* If you'd like your pattern to be configurable via the
@@ -63,6 +64,9 @@
              * If the user provided any values via the data-<%= appname %>
              * attribute, those values will already be set.
              */
+            // Just for the demo, do something:
+            this.$el.html("<%= appname %> is working!");
+            log.debug("pattern initialized");
         }
     });
 }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-patternslib",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A Yeoman generator for creating a Patternslib pattern",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
from the commit log:
- simplify makefile: all, clean, install, serve. no stamps, no designerhappy
- currently we need the resolutions section for jquery
- why not using latest http-server?
- removed stamp-bower and stamp-npm from Makefile, now also from gitignore
- add pattern class to dom element for a real demo. note NEEDS data element, otherwise parser breaks? reformat using 2 spaces indentation
- fix mainfile: let require depend on our app, wait for document loaded until running registry.init(), add missing dependencies, remove unnecessary dependencies
- let pattern do something simple for demo effects. name logger after app name. log something.
- require app_name, create app_name directory instead using current one, write main.js template, write indexfile with template substitions replaced correctly, restructure
- raise version

to test it, check this out, cd into it and do:

```
$ npm install
$ npm link
$ yo patternslib pat-test
```
